### PR TITLE
Note some connections may be lost when removing a process

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Now run another server process, and a few more. You'll see the kernel allows the
 
 Connect to the port. You'll see the kernel picks one of the processes and allows it to handle it. Next time it may be another process.
 
-You can add and remove processes. You can even run both the Python and Ruby processes at the same time and the kernel will share the workload.
+You can add and remove processes. You can even run both the Python and Ruby processes at the same time and the kernel will share the workload. However, note that queued connections which have not been accepted will be lost when stopping a process.
 
 More
 ----


### PR DESCRIPTION
The README (and the associated slides) presents this option as a magic bullet for high availability. However, queued connections that have not been accepted will be lost when stopping the "old" process.

There is unfortunately no easy way around as kernel maintainers didn't want to provide a simple option for that (like removing the `SO_REUSEPORT` option). It is believed that it could be done with BPF, but AFAIK nobody came up with actual code. The only solution for a seamless reload is to give the old socket to another instance.